### PR TITLE
changed parsing method for Parameters group

### DIFF
--- a/source/base/LKParameter.cpp
+++ b/source/base/LKParameter.cpp
@@ -117,7 +117,7 @@ void LKParameter::SetPar(TString name, TString raw, TString value, TString comme
         fCompare = compare;
 
     //int iSlash = fName.Index("/");
-    int iSlash = fName.Last('/');
+    int iSlash = fName.First('/');
     if (iSlash>=0) {
         fGroup    = fName(0,iSlash);
         fMainName = fName(iSlash+1,fName.Sizeof()-iSlash-2);


### PR DESCRIPTION
The parameter's group method changed in SetPar()
Once input parameters include the "G4/vis/scene/blabla 0 0",
This parameter group will be "G4/vis/scene/".
It doesn't work in Geant4 macros into G4UImanager (please see Line:157 in LKG4RunManager::Run)

I have changed this to get only the first slashed group
